### PR TITLE
fix: Correct DaemonSet selector labels

### DIFF
--- a/deploy/helm/templates/daemonset.yaml
+++ b/deploy/helm/templates/daemonset.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "nri-plugin.labels" . | nindent 6 }}
+      {{- include "nri-plugin.selectorLabels" . | nindent 6 }}
       {{- with .Values.podLabels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Removes the version-specific labels from the selector.
